### PR TITLE
Use gender neutral terms for contributor roles in french

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,9 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
+
+const { toLocaleDateString } = Date.prototype;
+// eslint-disable-next-line no-extend-native
+Date.prototype.toLocaleDateString = function mockedToLocaleDateString(locale = 'en-US', ...args) {
+  return toLocaleDateString.call(this, locale, ...args);
+};

--- a/src/template/translations/fr.js
+++ b/src/template/translations/fr.js
@@ -20,6 +20,6 @@ export default [
   { key: 'fr', text: 'Français' },
 
   /* Contributor roles */
-  { key: 'Cover artist', text: 'Illustrateur' },
-  { key: 'Translator', text: 'Traducteur' },
+  { key: 'Cover artist', text: 'Illustration' },
+  { key: 'Translator', text: 'Traduction' },
 ];


### PR DESCRIPTION
eg. "Traduction" instead of "Traducteur"